### PR TITLE
Fix media-button-inserter

### DIFF
--- a/inc/media-button.php
+++ b/inc/media-button.php
@@ -16,10 +16,13 @@ function pdfjs_media_button() {
 	printf(
 		wp_kses(
 			// translators: Add PDF.
-			__( '<a href="#" class="button js-insert-pdfjs">%s</a>', 'pdfjs-viewer-shortcode' ),
+			__( '<a href="#" class="button js-insert-pdfjs" id="insert-pdfjs">%s</a>', 'pdfjs-viewer-shortcode' ),
 			array(
-				'a'     => array( 'href' => array() ),
-				'class' => array(),
+				'a' => array( 
+					'href' => array(),
+					'class' => array(),
+					'id' => array(),
+				),
 			)
 		),
 		'Add PDF'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfjs-viewer-shortcode",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "main": "Gruntfile.js",
   "author": "Peter Hebert <peter@rexrana.ca>",
   "devDependencies": {

--- a/pdfjs-viewer-shortcode.php
+++ b/pdfjs-viewer-shortcode.php
@@ -8,7 +8,7 @@
  * Author URI:      https://rexrana.ca/
  * Text Domain:     pdfjs-viewer-shortcode
  * Domain Path:     /languages
- * Version:         1.6.3
+ * Version:         1.6.4
  * License:         GPLv2
  *
  * @package         Pdfjs_Viewer_Shortcode


### PR DESCRIPTION
Not sure how this was originally working: the `wp_kses` was stripping out the class, and the jQuery was referencing an id on this buttton:
https://github.com/rexrana/pdfjs-viewer-shortcode/blob/9d44779dd2a35b4c3b9bf31b1bb45199aaf97f79/js/pdfjs-media-button.js#L2C5-L2C23
